### PR TITLE
Bind-mount /vendor recursively

### DIFF
--- a/var/lib/lxc/android/config
+++ b/var/lib/lxc/android/config
@@ -24,5 +24,5 @@ lxc.mount.entry = sys sys sysfs nodev,noexec,nosuid 0 0
 #lxc.mount.entry = tmp tmp tmpfs nodev,noexec,nosuid 0 0
 lxc.mount.entry = /android/data data bind bind 0 0
 lxc.mount.entry = /mnt mnt bind rbind 0 0
-lxc.mount.entry = /vendor vendor bind bind 0 0
+lxc.mount.entry = /vendor vendor bind rbind 0 0
 


### PR DESCRIPTION
Required for some firmware files...

WiFi doesn't work on google_sargo without this.